### PR TITLE
Fix webpack deprecation messages ARRAY_TO_SET and COMPILATION_ASSETS

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -105,26 +105,24 @@ class TtagPlugin {
         childProcessDone => {
           childCompiler.runAsChild((err, entries, childCompilation) => {
             // name split-chunks with locale
-            compilation.chunks = compilation.chunks.concat(
-              childCompilation.chunks.map(ch => {
-                if (
-                  ch.chunkReason &&
-                  ch.chunkReason.startsWith("split chunk")
-                ) {
-                  ch.name = makeEntrypoint(locale, ch.name);
-                }
-                return ch;
-              })
-            );
+            childCompilation.chunks.forEach(childChunk => {
+              if (
+                childChunk.chunkReason &&
+                childChunk.chunkReason.startsWith("split chunk")
+              ) {
+                childChunk.name = makeEntrypoint(locale, childChunk.name);
+              }
+              compilation.chunks.add(childChunk);
+            });
             if (!err) {
-              compilation.assets = Object.assign(
-                childCompilation.assets,
-                compilation.assets
-              );
-              compilation.namedChunkGroups = Object.assign(
-                childCompilation.namedChunkGroups,
-                compilation.namedChunkGroups
-              );
+              compilation.assets = {
+                ...childCompilation.assets,
+                ...compilation.assets
+              };
+              compilation.namedChunkGroups = {
+                ...childCompilation.namedChunkGroups,
+                ...compilation.namedChunkGroups
+              };
             }
             err && compilation.errors.push(err);
             childProcessDone();

--- a/tests-unit/output.test.js
+++ b/tests-unit/output.test.js
@@ -67,7 +67,7 @@ test("should add vendor chunks from child compilation", async done => {
   });
 
   const stats = await runWebpack(compiler);
-  const chunkNames = stats.compilation.chunks.map(ch => ch.name);
+  const chunkNames = Array.from(stats.compilation.chunks).map(ch => ch.name);
   expect(chunkNames).toContain("vendors-uk");
   done();
 });


### PR DESCRIPTION
This PR fixes two webpack deprecation messages:

```
(node:32712) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: Compilation.chunks was changed from Array to Set (using Array method 'map' is deprecated)
```

The `.map` call in index.js did not actually return a different array, it was just a loop over the set of chunks. I replaced this with `.forEach`, which also took care of adding the chunks to the main compilation. This removed the need for using the `.concat` method, which also caused this warning.

```
(node:32712) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets will be frozen in future, all modifications are deprecated.
BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
        Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
        Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.
```

The call `Object.assign(childCompilation.assets, compilation.assets)` modifies its first argument, `childCompilation.assets`. At that point this object is frozen, causing this warning. Modification is not needed, as the only purpose of this code is to prepend the child compilations assets to the main compilations assets. I changed the implementation so `childCompilation.assets` is not modified.