### PR TITLE
Keep ttag.resolve configuration

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -137,7 +137,7 @@ class TtagPlugin {
 
   apply(compiler) {
     compiler.hooks.beforeRun.tapAsync(PLUGIN_NAME, (compiler, callback) => {
-      this.addDefaultResolve(compiler);
+      this.addResolveOpts(compiler);
       callback();
     });
     Object.entries(this.options.translations).forEach(
@@ -189,19 +189,12 @@ class TtagPlugin {
     }
   }
 
-  addResolveOpts(compiler, pofilePath) {
-    const ttagOpts = {
-      ...this.options.ttag,
-      ...{ resolve: { translations: pofilePath } }
-    };
-    setTtagOptions(compiler, ttagOpts);
-  }
-
-  addDefaultResolve(compiler) {
-    const ttagOpts = {
-      ...this.options.ttag,
-      ...{ resolve: { translations: "default" } }
-    };
+  addResolveOpts(compiler, pofilePath = "default") {
+    const ttagOpts = deepcopy(this.options.ttag);
+    if (!ttagOpts.resolve) {
+      ttagOpts.resolve = {};
+    }
+    ttagOpts.resolve.translations = pofilePath;
     setTtagOptions(compiler, ttagOpts);
   }
 }

--- a/tests-unit/entry.test.js
+++ b/tests-unit/entry.test.js
@@ -114,3 +114,29 @@ test("original entry should resolve to default", async done => {
   dir.cleanup();
   done();
 });
+
+test("should fail compilation for missing translation", async done => {
+  const dir = await tmp.dir({ unsafeCleanup: true });
+  const plugin = new TtagPlugin({
+    ttag: {
+      resolve: {
+        unresolved: "fail"
+      }
+    },
+    translations: {
+      uk: path.join(__dirname, "./fixtures/entry/entry.uk.po")
+    }
+  });
+
+  const compiler = getCompiler(plugin, {
+    output: { path: dir.path },
+    entry: {
+      entry: path.join(__dirname, "./fixtures/entry/entry3.js")
+    },
+    stats: "none"
+  });
+
+  await expect(runWebpack(compiler)).rejects.toThrow();
+  await dir.cleanup();
+  done();
+});

--- a/tests-unit/fixtures/entry/entry3.js
+++ b/tests-unit/fixtures/entry/entry3.js
@@ -1,0 +1,3 @@
+import { t } from "ttag";
+
+console.log(t`do not translate me`);

--- a/tests-unit/utils.js
+++ b/tests-unit/utils.js
@@ -42,10 +42,13 @@ export const getCompiler = (ttagPluging, webpackConf = {}) => {
 export const runWebpack = async compiler => {
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {
-      if (err || (stats && stats.hasErrors())) {
-        reject(stats.toString("normal"));
+      if (err) {
+        reject(err);
+      } else if (stats && stats.hasErrors()) {
+        reject(new Error(stats.toString("normal")));
+      } else {
+        resolve(stats);
       }
-      resolve(stats);
     });
   });
 };


### PR DESCRIPTION
This allows setting ttag.resolve.unresolved to fail to stop compilation when a translation is missing.

I also added a test to check if compilation fails when a text is missing.